### PR TITLE
Scheduler decorators

### DIFF
--- a/simso/core/Scheduler.py
+++ b/simso/core/Scheduler.py
@@ -53,9 +53,12 @@ class SchedulerInfo(object):
         try:
             clas = None
             if self.clas:
-                name = self.clas.rsplit('.', 1)[1]
-                importlib.import_module(self.clas)
-                clas = getattr(importlib.import_module(self.clas), name)
+                if type(self.clas) is type:
+                    clas = self.clas
+                else:
+                    name = self.clas.rsplit('.', 1)[1]
+                    importlib.import_module(self.clas)
+                    clas = getattr(importlib.import_module(self.clas), name)
             elif self.filename:
                 path, name = os.path.split(self.filename)
                 name = os.path.splitext(name)[0]

--- a/simso/schedulers/BF.py
+++ b/simso/schedulers/BF.py
@@ -3,10 +3,12 @@ Implementation of the BF algorithm.
 
 Authors: Maxime Cheramy and Stefan Junker
 """
+from simso.schedulers import scheduler
 from simso.core import Scheduler, Timer
 from fractions import Fraction
 
 
+@scheduler("simso.schedulers.BF")
 class BF(Scheduler):
     def init(self):
         self.t_f = 0

--- a/simso/schedulers/CC_EDF.py
+++ b/simso/schedulers/CC_EDF.py
@@ -4,11 +4,7 @@ Cycle-Conserving EDF. A DVFS variant of EDF (uniprocessor).
 from simso.core import Scheduler
 from simso.schedulers import scheduler
 
-@scheduler("simso.schedulers.CC_EDF", 
-    required_proc_fields = [
-        { 'name': 'priority', 'type': 'float', 'default': '1.0' }
-    ]
-)
+@scheduler("simso.schedulers.CC_EDF")
 class CC_EDF(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/CC_EDF.py
+++ b/simso/schedulers/CC_EDF.py
@@ -4,7 +4,11 @@ Cycle-Conserving EDF. A DVFS variant of EDF (uniprocessor).
 from simso.core import Scheduler
 from simso.schedulers import scheduler
 
-@scheduler("simso.schedulers.CC_EDF")
+@scheduler("simso.schedulers.CC_EDF",
+           required_proc_fields = [
+               { 'name': 'speed', 'type': 'float', 'default': '1.0' }
+           ]
+)
 class CC_EDF(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/CC_EDF.py
+++ b/simso/schedulers/CC_EDF.py
@@ -2,8 +2,13 @@
 Cycle-Conserving EDF. A DVFS variant of EDF (uniprocessor).
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.CC_EDF", 
+    required_proc_fields = [
+        { 'name': 'priority', 'type': 'float', 'default': '1.0' }
+    ]
+)
 class CC_EDF(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/DP_WRAP.py
+++ b/simso/schedulers/DP_WRAP.py
@@ -4,8 +4,9 @@ Implementation of the DP-WRAP algorithm as presented by Levin et al. in
 """
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.DP_WRAP")
 class DP_WRAP(Scheduler):
     def init(self):
         self.t_f = 0

--- a/simso/schedulers/EDCL.py
+++ b/simso/schedulers/EDCL.py
@@ -4,8 +4,9 @@ __author__ = 'Pierre-Emmanuel Hladik'
 
 
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EDCL")
 class EDCL(Scheduler):
     """
     EDCL Scheduler.

--- a/simso/schedulers/EDF.py
+++ b/simso/schedulers/EDF.py
@@ -3,8 +3,9 @@ Implementation of the Global-EDF (Earliest Deadline First) for multiprocessor
 architectures.
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EDF")
 class EDF(Scheduler):
     """Earliest Deadline First"""
     def on_activate(self, job):

--- a/simso/schedulers/EDF2.py
+++ b/simso/schedulers/EDF2.py
@@ -3,8 +3,9 @@ Implementation of the Global-EDF (Earliest Deadline First) for multiprocessor
 architectures (alternative implementation as the one provided by EDF.py).
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EDF2")
 class EDF2(Scheduler):
     """Earliest Deadline First"""
     def init(self):

--- a/simso/schedulers/EDF_US.py
+++ b/simso/schedulers/EDF_US.py
@@ -2,8 +2,9 @@
 Implementation of EDF-US[1/2].
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EDF_US")
 class EDF_US(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/EDF_mono.py
+++ b/simso/schedulers/EDF_mono.py
@@ -2,8 +2,9 @@
 Earliest Deadline First algorithm for uniprocessor architectures.
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EDF_mono")
 class EDF_mono(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/EDHS.py
+++ b/simso/schedulers/EDHS.py
@@ -8,12 +8,12 @@ from simso.core import Scheduler, Timer
 from simso.core.Scheduler import SchedulerInfo
 from fractions import Fraction
 from math import ceil
+from simso.schedulers import scheduler
 
 migrating_tasks = {}
 
 # Mapping processor to scheduler.
 map_cpu_sched = {}
-
 
 class EDF_modified(Scheduler):
     """
@@ -69,6 +69,7 @@ class EDF_modified(Scheduler):
         return (job, cpu)
 
 
+@scheduler("simso.schedulers.EDHS")
 class EDHS(Scheduler):
     def init(self):
         # Mapping task to scheduler.

--- a/simso/schedulers/EDZL.py
+++ b/simso/schedulers/EDZL.py
@@ -2,8 +2,9 @@
 # coding=utf-8
 
 from simso.core import Scheduler, Timer
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EDZL")
 class EDZL(Scheduler):
     """
     EDZL Scheduler. EDF Scheduler with zero laxity events.

--- a/simso/schedulers/EKG.py
+++ b/simso/schedulers/EKG.py
@@ -2,6 +2,7 @@ from simso.core import Scheduler, Timer
 from simso.core.Scheduler import SchedulerInfo
 from fractions import Fraction
 from math import ceil
+from simso.schedulers import scheduler
 
 
 class Modified_EDF(Scheduler):
@@ -85,7 +86,11 @@ class Group(object):
                     for task in self.tasks if task.jobs]) \
             * self.sim.cycles_per_ms
 
-
+@scheduler("simso.schedulers.EKG", 
+    required_fields = [
+        {'name' : 'K', 'type' : 'int', 'default' : '0'}
+    ]
+)
 class EKG(Scheduler):
     def init(self):
         self.groups = []

--- a/simso/schedulers/EPDF.py
+++ b/simso/schedulers/EPDF.py
@@ -2,8 +2,9 @@
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.EPDF")
 class EPDF(Scheduler):
     """Earliest Pseudo-Deadline First"""
 

--- a/simso/schedulers/ER_PD2.py
+++ b/simso/schedulers/ER_PD2.py
@@ -2,6 +2,7 @@
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
 
 def rounded_wcet(job, q=None):
@@ -88,7 +89,7 @@ class PseudoJob(object):
         return int(ceil(seq * job.deadline / rounded_wcet(job))) \
             - int((seq - 1) * job.deadline / rounded_wcet(job))
 
-
+@scheduler("simso.schedulers.ER_PD2")
 class ER_PD2(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/FP.py
+++ b/simso/schedulers/FP.py
@@ -2,8 +2,13 @@
 # coding=utf-8
 
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.FP", 
+    required_task_fields = [
+        {'name': 'priority', 'type' : 'int', 'default' : '0' }   
+    ]
+)
 class FP(Scheduler):
     """ Fixed Priority (use 'priority' field) """
     def init(self):

--- a/simso/schedulers/Fixed_PEDF.py
+++ b/simso/schedulers/Fixed_PEDF.py
@@ -4,8 +4,9 @@
 from simso.core.Scheduler import SchedulerInfo
 from simso.schedulers.EDF_mono import EDF_mono
 from simso.utils import PartitionedScheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.Fixed_PEDF")
 class Fixed_PEDF(PartitionedScheduler):
     def init(self):
         PartitionedScheduler.init(self, SchedulerInfo("EDF_mono", EDF_mono))

--- a/simso/schedulers/G_FL.py
+++ b/simso/schedulers/G_FL.py
@@ -4,8 +4,9 @@ Anderson in Fair lateness scheduling: Reducing maximum lateness in G-EDF-like
 scheduling.
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.G_FL")
 class G_FL(Scheduler):
     """Earliest Deadline First"""
     def init(self):

--- a/simso/schedulers/G_FL_ZL.py
+++ b/simso/schedulers/G_FL_ZL.py
@@ -1,6 +1,7 @@
 from simso.core import Scheduler, Timer
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.G_FL_ZL")
 class G_FL_ZL(Scheduler):
     """
     G_FL with Zero Laxity Scheduler.

--- a/simso/schedulers/LB_P_EDF.py
+++ b/simso/schedulers/LB_P_EDF.py
@@ -5,8 +5,9 @@ Try to load balance the tasks among the processors.
 from simso.core.Scheduler import SchedulerInfo
 from simso.schedulers.EDF_mono import EDF_mono
 from simso.utils import PartitionedScheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.LB_P_EDF")
 class LB_P_EDF(PartitionedScheduler):
     def init(self):
         PartitionedScheduler.init(self, SchedulerInfo("simso.schedulers.EDF_mono"))

--- a/simso/schedulers/LLF.py
+++ b/simso/schedulers/LLF.py
@@ -1,6 +1,7 @@
 from simso.core import Scheduler, Timer
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.LLF")
 class LLF(Scheduler):
     """Least Laxity First"""
     def init(self):

--- a/simso/schedulers/LLREF.py
+++ b/simso/schedulers/LLREF.py
@@ -5,8 +5,9 @@ Implementation of the LLREF scheduler as presented by Cho et al. in
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.LLREF")
 class LLREF(Scheduler):
     def init(self):
         self.selected_jobs = []  # Jobs currently running.

--- a/simso/schedulers/LLREF2.py
+++ b/simso/schedulers/LLREF2.py
@@ -5,8 +5,9 @@ Implementation of the LLREF scheduler as presented by Cho et al. in
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.LLREF2")
 class LLREF2(Scheduler):
     def init(self):
         self.selected_jobs = []  # Jobs currently running.

--- a/simso/schedulers/LRE_TL.py
+++ b/simso/schedulers/LRE_TL.py
@@ -6,8 +6,9 @@ Optimal Multiprocessor Scheduling Algorithm for Sporadic Task Sets".
 from simso.core import Scheduler, Timer
 from heapq import heappush, heapreplace, heappop, heapify
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.LRE_TL")
 class LRE_TL(Scheduler):
     def init(self):
         """

--- a/simso/schedulers/MLLF.py
+++ b/simso/schedulers/MLLF.py
@@ -1,6 +1,7 @@
 from simso.core import Scheduler, Timer
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.MLLF")
 class MLLF(Scheduler):
     """Modified Least Laxity First"""
     def init(self):

--- a/simso/schedulers/NVNLF.py
+++ b/simso/schedulers/NVNLF.py
@@ -6,8 +6,9 @@ Multiprocessors."
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.NVNLF")
 class NVNLF(Scheduler):
     def init(self):
         self.selected_jobs = []  # Jobs currently running.

--- a/simso/schedulers/PD2.py
+++ b/simso/schedulers/PD2.py
@@ -2,6 +2,7 @@
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
 
 def rounded_wcet(job, q=None):
@@ -88,7 +89,7 @@ class PseudoJob(object):
         return int(ceil(seq * job.deadline / rounded_wcet(job))) \
             - int((seq - 1) * job.deadline / rounded_wcet(job))
 
-
+@scheduler("simso.schedulers.PD2")
 class PD2(Scheduler):
     quantum = 100000  # cycles
 

--- a/simso/schedulers/P_EDF.py
+++ b/simso/schedulers/P_EDF.py
@@ -4,8 +4,9 @@ Partitionned EDF using PartitionedScheduler.
 from simso.core.Scheduler import SchedulerInfo
 from simso.utils import PartitionedScheduler
 from simso.utils.PartitionedScheduler import decreasing_first_fit
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.P_EDF")
 class P_EDF(PartitionedScheduler):
     def init(self):
         PartitionedScheduler.init(

--- a/simso/schedulers/P_EDF2.py
+++ b/simso/schedulers/P_EDF2.py
@@ -6,8 +6,9 @@ Use EDF_mono.
 from simso.core import Scheduler
 from simso.core.Scheduler import SchedulerInfo
 from simso.schedulers.EDF_mono import EDF_mono
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.P_EDF2")
 class P_EDF2(Scheduler):
     def init(self):
         # Mapping processor to scheduler.

--- a/simso/schedulers/P_EDF_WF.py
+++ b/simso/schedulers/P_EDF_WF.py
@@ -5,8 +5,9 @@ from simso.core.Scheduler import SchedulerInfo
 from simso.schedulers.EDF_mono import EDF_mono
 from simso.utils import PartitionedScheduler
 from simso.utils.PartitionedScheduler import decreasing_worst_fit
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.P_EDF_WF")
 class P_EDF_WF(PartitionedScheduler):
     def init(self):
         PartitionedScheduler.init(

--- a/simso/schedulers/P_RM.py
+++ b/simso/schedulers/P_RM.py
@@ -3,8 +3,9 @@ Partitionned EDF using PartitionedScheduler.
 """
 from simso.core.Scheduler import SchedulerInfo
 from simso.utils import PartitionedScheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.P_RM")
 class P_RM(PartitionedScheduler):
     def init(self):
         PartitionedScheduler.init(

--- a/simso/schedulers/PriD.py
+++ b/simso/schedulers/PriD.py
@@ -4,8 +4,9 @@ Priority-Driven Scheduling of Periodic Task Systems on Multiprocessors.
 """
 from simso.core import Scheduler
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.PriD")
 class PriD(Scheduler):
     """EDF(k) scheduler"""
     def init(self):

--- a/simso/schedulers/RM.py
+++ b/simso/schedulers/RM.py
@@ -1,6 +1,7 @@
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.RM")
 class RM(Scheduler):
     """ Rate monotonic """
     def init(self):

--- a/simso/schedulers/RM_mono.py
+++ b/simso/schedulers/RM_mono.py
@@ -2,8 +2,9 @@
 Rate Monotic algorithm for uniprocessor architectures.
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.RM_mono")
 class RM_mono(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/RUN.py
+++ b/simso/schedulers/RUN.py
@@ -10,8 +10,9 @@ tasks with implicit deadlines.
 from simso.core import Scheduler, Timer
 from simso.schedulers.RUNServer import EDFServer, TaskServer, DualServer, \
     select_jobs, add_job, get_child_tasks
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.RUN")
 class RUN(Scheduler):
     """
     RUN scheduler. The offline part is done here but the online part is mainly

--- a/simso/schedulers/Static_EDF.py
+++ b/simso/schedulers/Static_EDF.py
@@ -2,8 +2,13 @@
 Static EDF. A DVFS variant of EDF (uniprocessor).
 """
 from simso.core import Scheduler
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.Static_EDF", 
+           required_proc_fields = [
+               { 'name': 'priority', 'type': 'float', 'default': '1.0' }
+           ]
+)
 class Static_EDF(Scheduler):
     def init(self):
         self.ready_list = []

--- a/simso/schedulers/Static_EDF.py
+++ b/simso/schedulers/Static_EDF.py
@@ -6,7 +6,7 @@ from simso.schedulers import scheduler
 
 @scheduler("simso.schedulers.Static_EDF", 
            required_proc_fields = [
-               { 'name': 'priority', 'type': 'float', 'default': '1.0' }
+               { 'name': 'speed', 'type': 'float', 'default': '1.0' }
            ]
 )
 class Static_EDF(Scheduler):

--- a/simso/schedulers/U_EDF.py
+++ b/simso/schedulers/U_EDF.py
@@ -7,8 +7,9 @@ tasks"
 
 from simso.core import Scheduler, Timer
 from math import ceil
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.U_EDF")
 class U_EDF(Scheduler):
     def init(self):
         self.al = {}

--- a/simso/schedulers/WC_RUN.py
+++ b/simso/schedulers/WC_RUN.py
@@ -3,8 +3,9 @@ Work-Conserving version of U-EDF.
 """
 
 from simso.schedulers.RUN import RUN
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.WC_RUN")
 class WC_RUN(RUN):
     def init(self):
         RUN.init(self)

--- a/simso/schedulers/WC_U_EDF.py
+++ b/simso/schedulers/WC_U_EDF.py
@@ -3,8 +3,9 @@ Work-Conserving version of U-EDF.
 """
 
 from simso.schedulers.U_EDF import U_EDF
+from simso.schedulers import scheduler
 
-
+@scheduler("simso.schedulers.WC_U_EDF")
 class WC_U_EDF(U_EDF):
 #    def on_terminated(self, job):
 #        self.reschedule()

--- a/simso/schedulers/__init__.py
+++ b/simso/schedulers/__init__.py
@@ -1,0 +1,50 @@
+# List of all schedulers that have been declared using
+# the @scheduler decorator.
+__loaded_schedulers = []
+
+# Decorator used to register a scheduler to be returned by get_declared_schedulers()
+def scheduler(name, **kwargs):
+	"""
+	Decorator used to register a scheduler to be returned by get_declared_schedulers().
+	Mandatory arguments : 
+		name : the complete name of the scheduler (ex : simso.schedulers.EDF)
+	Optional keyword arguments : 
+		display_name : name to be shown to the user
+		required_fields : list of required fields for this scheduler to work correctly.
+			It should be a dict with the following keys : 
+				name: name of the field
+				type: type of the field
+				default: default value of the field
+		required_task_fields : list of required fields for this scheduler's tasks
+			to work correctly. Same format as required_fields
+		required_proc_fields : list of required fields for this scheduler's processors
+			to work correctly. Same format as required_fields
+				
+	The list of registered schedulers is mostly used in graphical interfaces to auto-detect
+	the exposed schedulers.
+	"""
+	required_fields = kwargs['required_fields'] if 'required_fields' in kwargs else []
+	task_f = kwargs['required_task_fields'] if 'required_task_fields' in kwargs else []
+	proc_f = kwargs['required_proc_fields'] if 'required_proc_fields' in kwargs else []
+	display_name = kwargs['display_name'] if 'display_name' in kwargs else name
+	def f(klass):
+		# Note : 
+		# We didn't include this data into the classes because it didn't work
+		# properly with inheritance.
+		# klass.simso_name = name
+		# klass.simso_required_fields = required_fields
+		# klass.simso_required_task_fields = task_f
+		# klass.simso_required_proc_fields = proc_f
+		__loaded_schedulers.append({
+			'name': name,
+			'display_name': display_name,
+			'required_fields': required_fields,
+			'required_task_fields': task_f,
+			'required_proc_fields': proc_f
+		})
+		return klass
+		
+	return f
+
+def get_loaded_schedulers():
+	return __loaded_schedulers


### PR DESCRIPTION
Added scheduler decorators to register all the imported schedulers and their dependencies in terms of custom fields (for schedulers, tasks, or processors). This is can be used to create GUI's that automatically adapt to each scheduler by showing custom fields.