### PR TITLE
Fix exception 'UnboundLocalError: local variable 'nextSumU' reference…

### DIFF
--- a/simso/generator/task_generator.py
+++ b/simso/generator/task_generator.py
@@ -12,12 +12,12 @@ def UUniFastDiscard(n, u, nsets):
     while len(sets) < nsets:
         # Classic UUniFast algorithm:
         utilizations = []
-        sumU = u
+        remainingU = u
         for i in range(1, n):
-            nextSumU = sumU * random.random() ** (1.0 / (n - i))
-            utilizations.append(sumU - nextSumU)
-            sumU = nextSumU
-        utilizations.append(nextSumU)
+            r = random.random() ** (1.0 / (n - i))
+            utilizations.append(remainingU * (1-r))
+            remainingU *= r
+        utilizations.append(remainingU)
 
         # If no task utilization exceeds 1:
         if not [ut for ut in utilizations if ut > 1]:


### PR DESCRIPTION
Fix exception 'UnboundLocalError: local variable 'nextSumU' referenced before assignment' when calling UUniFastDiscard() with parameters n=1