### PR TITLE
Replace usage of deprecated imp with importlib

### DIFF
--- a/simso/core/Scheduler.py
+++ b/simso/core/Scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import sys
-import imp
 import os.path
 import importlib
 import pkgutil
@@ -57,18 +56,19 @@ class SchedulerInfo(object):
                     clas = self.clas
                 else:
                     name = self.clas.rsplit('.', 1)[1]
-                    importlib.import_module(self.clas)
-                    clas = getattr(importlib.import_module(self.clas), name)
+                    module = importlib.import_module(self.clas)
+                    clas = getattr(module, name)
             elif self.filename:
                 path, name = os.path.split(self.filename)
-                name = os.path.splitext(name)[0]
-
-                fp, pathname, description = imp.find_module(name, [path])
+                module_name = os.path.splitext(name)[0]
+		
                 if path not in sys.path:
                     sys.path.append(path)
-                clas = getattr(imp.load_module(name, fp, pathname,
-                                               description), name)
-                fp.close()
+
+                spec = importlib.util.spec_from_file_location(module_name, self.filename)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                clas = getattr(module, module_name)                    
 
             return clas
         except Exception as e:


### PR DESCRIPTION
Title: Replace usage of imp with importlib to support Python 3.12

Description:

Dynamic loading of a scheduler defined in a configuration from a python file was based on the imp module, which has been deprecated since Python 3.4 and was removed in Python 3.12. The recommended module now is importlib, which was already used in the code for importing a scheduler as a class.

Changes:
- Replaced functions imp.find_module and imp.load_module with importlib.util.spec_from_file_location and importlib.util.module_from_spec in Scheduler.py (get_cls() function)